### PR TITLE
pdf 반영 스크립트 추가

### DIFF
--- a/README_ko.md
+++ b/README_ko.md
@@ -57,3 +57,14 @@ python run_bot.py
 
 - 모든 설정은 DB의 `system_config` 테이블에서 로드됩니다.
 - `initialize()` 호출 시 DB 테이블이 자동으로 생성되며 `/metrics` 경로가 노출됩니다.
+
+## PDF 문서 변환
+
+`Sigma-X 자동매매 시스템 아키텍처 분석.pdf` 파일의 내용을 텍스트로 활용하려면
+다음 스크립트를 실행합니다.
+
+```bash
+python scripts/pdf_to_md.py 'Sigma-X 자동매매 시스템 아키텍처 분석.pdf' docs/architecture_summary.md
+```
+
+`docs/architecture_summary.md` 파일이 생성되면 내용을 검토 후 서식을 정리해 사용합니다.

--- a/docs/architecture_summary.md
+++ b/docs/architecture_summary.md
@@ -1,0 +1,11 @@
+# Sigma-X 아키텍처 요약
+
+이 문서는 `Sigma-X 자동매매 시스템 아키텍처 분석.pdf` 파일의 내용을 텍스트로 추출해 정리하기 위한 자리표시자입니다.
+
+현재 환경에서는 PDF 내용을 직접 읽을 수 없으므로 `scripts/pdf_to_md.py` 스크립트를 사용해 텍스트를 추출한 뒤 이 파일을 업데이트해야 합니다.
+
+```bash
+python scripts/pdf_to_md.py 'Sigma-X 자동매매 시스템 아키텍처 분석.pdf' docs/architecture_summary.md
+```
+
+명령 실행 후 생성된 내용이 올바른지 확인하고 필요한 서식을 추가해 주시기 바랍니다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,5 +6,6 @@
 
 - [서버 정보 및 개발 가이드](README_ko.md)
 - [모듈 사양서 목차](../spec/sigma_spec.md)
+- [아키텍처 요약](architecture_summary.md)
 
 향후 문서가 추가되면 이곳에 목록을 갱신합니다.

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ python-dateutil
 # 모니터링
 prometheus-client
 
+PyPDF2

--- a/scripts/pdf_to_md.py
+++ b/scripts/pdf_to_md.py
@@ -1,0 +1,34 @@
+"""PDF 파일을 읽어 마크다운 파일로 저장하는 스크립트.
+
+PyPDF2 라이브러리에 의존하며, PDF 내부 텍스트를 추출해 단순히 이어 붙인 후
+지정한 마크다운 파일에 기록합니다. 환경에 따라 정확도가 달라질 수 있으므로
+추출 후 내용을 검토해 수정하는 과정을 권장합니다.
+"""
+
+from pathlib import Path
+
+try:
+    from PyPDF2 import PdfReader
+except ImportError as e:
+    raise SystemExit(
+        "PyPDF2가 설치되어 있지 않습니다. requirements.txt를 확인하세요"
+    ) from e
+
+
+def pdf_to_markdown(pdf_path: str, md_path: str) -> None:
+    """주어진 PDF 파일을 읽어 텍스트를 추출 후 마크다운 파일로 저장."""
+    reader = PdfReader(pdf_path)
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    Path(md_path).write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="PDF를 마크다운으로 변환")
+    parser.add_argument("pdf", help="원본 PDF 파일 경로")
+    parser.add_argument("output", help="생성할 마크다운 파일 경로")
+    args = parser.parse_args()
+
+    pdf_to_markdown(args.pdf, args.output)
+    print(f"완료: {args.output} 파일이 생성되었습니다.")


### PR DESCRIPTION
## 변경 내용
- PDF 내용을 추출할 수 있는 `scripts/pdf_to_md.py` 스크립트 추가
- 아키텍처 요약 문서 `docs/architecture_summary.md` 생성
- `docs/index.md`와 `README_ko.md`에 사용 방법 설명
- `requirements.txt`에 `PyPDF2` 의존성 명시

## 테스트 결과
- `pytest -q` 실행하여 모든 테스트 통과