### PR TITLE
서버 스펙 문서 링크 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # SIGMA 프로젝트
 
 새로운 아키텍처 문서는 `docs/` 디렉터리에서 확인할 수 있습니다. 기존 소스와 문서는 `archive/`와 `docs/9_archive/`에 보존됩니다.
+
+서버 기본 사양은 [docs/requirements/Server_Spec.md](docs/requirements/Server_Spec.md)에서 확인할 수 있습니다.

--- a/docs/0_overview/README.md
+++ b/docs/0_overview/README.md
@@ -8,3 +8,4 @@
 - `4_development/` : 개발 규칙과 플러그인, **모듈별 사양서**
 - `5_testing/` : 테스트 및 성능 검증 기준
 - `9_archive/` : 이전 버전 문서 보관소
+- [`../requirements/Server_Spec.md`](../requirements/Server_Spec.md) : 서버 기본 사양

--- a/docs/3_deployment/Deploy_CICD_Guide.md
+++ b/docs/3_deployment/Deploy_CICD_Guide.md
@@ -1,3 +1,5 @@
 # 배포 및 CI/CD 가이드
 
 GitHub Actions를 활용하여 테스트 후 Docker 이미지를 빌드하고 배포합니다. `docker compose` 파일로 단일 VPS에서 실행합니다.
+
+자세한 서버 사양은 [../requirements/Server_Spec.md](../requirements/Server_Spec.md)을 참고하세요.

--- a/docs/requirements/Server_Spec.md
+++ b/docs/requirements/Server_Spec.md
@@ -1,0 +1,21 @@
+# SIGMA VPS 서버 사양
+
+이 문서는 SIGMA 자동매매 시스템이 운영되는 VPS의 기본 사양을 정의합니다. 환경 변수로 값을 재정의할 수 있으며, 기본값은 코드의 `DEFAULT_SPEC`에 명시되어 있습니다.
+
+| 항목 | 기본값 |
+| --- | --- |
+| 플랫폼 | Naver Cloud Platform (VPC 환경) |
+| 서버 이름 | sigma (ID: 105080454) |
+| 공인 IP | 223.130.139.218 |
+| 비공인 IP | 10.0.1.6 |
+| 이미지 | Ubuntu 24.04 LTS (ubuntu-24.04-base) |
+| 서버 사양 | s4-g3 (vCPU 4개 / 메모리 16GB) |
+| 스토리지 | 100GB SSD(`/dev/vda`) |
+| 하이퍼바이저 | KVM |
+| 서버 상태 | 운영 중 |
+| 생성일시 | 2025-05-12 16:32 (KST) |
+| 구동일시 | 2025-05-19 19:57 (KST) |
+| VPC 이름 | sigma-vpc |
+| Subnet | public-subnet1 (KR-1) |
+
+환경 변수 `SIGMA_PLATFORM` 등으로 각 값을 변경하여 사용할 수 있습니다.

--- a/sigma/__init__.py
+++ b/sigma/__init__.py
@@ -1,0 +1,7 @@
+from .server_config import ServerSpec, load_server_spec, DEFAULT_SPEC
+
+__all__ = [
+    "ServerSpec",
+    "load_server_spec",
+    "DEFAULT_SPEC",
+]

--- a/sigma/server_config.py
+++ b/sigma/server_config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class ServerSpec:
+    """서버 스펙 정보를 저장합니다."""
+
+    platform: str
+    server_name: str
+    public_ip: str
+    private_ip: str
+    image: str
+    spec: str
+    storage: str
+    hypervisor: str
+    status: str
+    created_at: str
+    started_at: str
+    vpc_name: str
+    subnet: str
+
+
+DEFAULT_SPEC = ServerSpec(
+    platform="Naver Cloud Platform (VPC 환경)",
+    server_name="sigma (ID: 105080454)",
+    public_ip="223.130.139.218",
+    private_ip="10.0.1.6",
+    image="Ubuntu 24.04 LTS (ubuntu-24.04-base)",
+    spec="s4-g3 (vCPU 4개 / 메모리 16GB)",
+    storage="100GB SSD (/dev/vda)",
+    hypervisor="KVM",
+    status="운영 중",
+    created_at="2025-05-12 16:32 (KST)",
+    started_at="2025-05-19 19:57 (KST)",
+    vpc_name="sigma-vpc",
+    subnet="public-subnet1 (KR-1)",
+)
+
+
+def load_server_spec() -> ServerSpec:
+    """환경 변수에서 서버 스펙을 로드하고 없으면 기본값을 사용합니다."""
+
+    return ServerSpec(
+        platform=os.getenv("SIGMA_PLATFORM", DEFAULT_SPEC.platform),
+        server_name=os.getenv("SIGMA_SERVER_NAME", DEFAULT_SPEC.server_name),
+        public_ip=os.getenv("SIGMA_PUBLIC_IP", DEFAULT_SPEC.public_ip),
+        private_ip=os.getenv("SIGMA_PRIVATE_IP", DEFAULT_SPEC.private_ip),
+        image=os.getenv("SIGMA_IMAGE", DEFAULT_SPEC.image),
+        spec=os.getenv("SIGMA_SPEC", DEFAULT_SPEC.spec),
+        storage=os.getenv("SIGMA_STORAGE", DEFAULT_SPEC.storage),
+        hypervisor=os.getenv("SIGMA_HYPERVISOR", DEFAULT_SPEC.hypervisor),
+        status=os.getenv("SIGMA_STATUS", DEFAULT_SPEC.status),
+        created_at=os.getenv("SIGMA_CREATED_AT", DEFAULT_SPEC.created_at),
+        started_at=os.getenv("SIGMA_STARTED_AT", DEFAULT_SPEC.started_at),
+        vpc_name=os.getenv("SIGMA_VPC_NAME", DEFAULT_SPEC.vpc_name),
+        subnet=os.getenv("SIGMA_SUBNET", DEFAULT_SPEC.subnet),
+    )
+
+
+__all__ = ["ServerSpec", "load_server_spec", "DEFAULT_SPEC"]

--- a/tests/test_benchmark_server_config.py
+++ b/tests/test_benchmark_server_config.py
@@ -1,0 +1,6 @@
+from sigma.server_config import load_server_spec
+
+
+def test_benchmark_load_server_spec(benchmark):
+    result = benchmark(load_server_spec)
+    assert result.public_ip

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,0 +1,14 @@
+import os
+from sigma.server_config import load_server_spec, DEFAULT_SPEC, ServerSpec
+
+
+def test_load_server_spec_defaults():
+    spec = load_server_spec()
+    assert spec == DEFAULT_SPEC
+
+
+def test_load_server_spec_env(monkeypatch):
+    monkeypatch.setenv("SIGMA_SERVER_NAME", "custom-sigma")
+    spec = load_server_spec()
+    assert spec.server_name == "custom-sigma"
+    assert spec.public_ip == DEFAULT_SPEC.public_ip


### PR DESCRIPTION
## 변경 내용
- README와 주요 문서에 VPS 사양 문서를 연결했습니다.
- `sigma/__init__.py`에서 서버 설정 모듈을 내보내도록 수정했습니다.

## 테스트 결과
- `pytest --cov=sigma -q` 실행 시 모든 테스트가 통과했습니다.