### PR TITLE
Apply naming updates and docs sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# SIGMA-X 프로젝트
+
+SIGMA-X는 단일 VPS에서 동작하는 자동 매매 시스템입니다. 실전(LIVE), 시뮬레이션(SIM), 백테스트(BACKTEST) 모드가 동일한 코드 경로로 실행되도록 설계되었습니다.
+
+## 설치 방법
+```bash
+pip install -r requirements.txt
+```
+
+## 실행 예시
+```bash
+python src/sigma/run_bot.py --mode live
+```
+
+자세한 아키텍처 설명과 모듈 사양서는 `docs/` 디렉터리를 참고하세요.

--- a/docs/4_development/module_specs/common/Metrics_Spec.md
+++ b/docs/4_development/module_specs/common/Metrics_Spec.md
@@ -15,7 +15,7 @@
 * 포함된 클래스/함수: `MetricsTracker`, `collect_pnl`, `collect_latency`
 * 주요 메서드: `push_metrics()`, `start()`
 * 외부 API 제공 여부: 없음
-* 소스 파일 위치: `sigma/metrics.py`
+* 소스 파일 위치: `sigma/metrics.py` (모듈에서 `MetricsTracker` 클래스를 제공)
 
 ## 3. 인터페이스 명세
 ### 3.1 입력

--- a/docs/4_development/module_specs/interfaces/MarketDataWebSocket_Spec.md
+++ b/docs/4_development/module_specs/interfaces/MarketDataWebSocket_Spec.md
@@ -15,7 +15,7 @@
 * 포함된 클래스/함수: `WebSocketClient`, `UpbitStream`, `BinanceStream`
 * 주요 메서드: `connect()`, `subscribe()`, `forward_tick()`
 * 외부 API 제공 여부: 없음
-* 소스 파일 위치: `sigma/market_ws.py`
+* 소스 파일 위치: `sigma/market_data_websocket.py`
 
 ## 3. 인터페이스 명세
 ### 3.1 입력

--- a/src/sigma/dashboard_api.py
+++ b/src/sigma/dashboard_api.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, FastAPI
 from typing import Any, Dict
 
 
-class DashboardApi:
+class DashboardAPI:
     def __init__(self, session_manager, system_status, ws_endpoint, logger=None) -> None:
         self.session_manager = session_manager
         self.system_status = system_status

--- a/src/sigma/market_data_websocket.py
+++ b/src/sigma/market_data_websocket.py
@@ -18,7 +18,7 @@ class DummyRedis:
         print(f"{channel}: {message}")
 
 
-class MarketWs:
+class MarketDataWebSocket:
     """거래소 WebSocket을 연결하고 틱 데이터를 Redis로 전달한다."""
 
     def __init__(


### PR DESCRIPTION
## Summary
- rename `MarketWs` to `MarketDataWebSocket`
- rename `DashboardApi` class to `DashboardAPI`
- clarify MetricsTracker specification
- provide Korean `README.md`

## Testing
- `pytest -q`