### PR TITLE
Fix WebSocket debug logging

### DIFF
--- a/tests/test_market_data_websocket.py
+++ b/tests/test_market_data_websocket.py
@@ -1,0 +1,16 @@
+import logging
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from sigma.market_data_websocket import DummyRedis
+
+
+def test_dummyredis_publish_logs(caplog):
+    logger = logging.getLogger("test")
+    dummy = DummyRedis(logger=logger)
+    with caplog.at_level(logging.DEBUG):
+        asyncio.run(dummy.publish("chan", "msg"))
+    assert "chan: msg" in caplog.text


### PR DESCRIPTION
## Summary
- log outgoing messages via logger in DummyRedis
- pass logger to DummyRedis from MarketDataWebSocket
- test logging output with pytest

## Testing
- `flake8 src/sigma/market_data_websocket.py tests/test_market_data_websocket.py`
- `pytest -q`