### PR TITLE
Fix architecture doc version

### DIFF
--- a/docs/1_architecture/SIGMA_Architecture_v1.2.md
+++ b/docs/1_architecture/SIGMA_Architecture_v1.2.md
@@ -1,4 +1,4 @@
-# SIGMA Architecture v1.4
+# SIGMA Architecture v1.2
 
 ## 1. Purpose & Scope
 
@@ -267,7 +267,5 @@
 | v1.0     | 2025-05-21 | Baseline (거래 5 모듈)                                      |
 | v1.1     | 2025-05-22 | Metrics·Notification·Dashboard 추가                       |
 | v1.2 | 2025-05-22 | SimulatorExecutor · HistoricalDataLoader 통합, 다이어그램/표 갱신 |
-| **v1.3** | 2025-05-23 | 3번 다이어그램 기반 전체 항목 개편 |
-| **v1.4** | 2025-05-23 | DashboardAPI 모듈 추가 |
 
 ---

--- a/scripts/check_architecture_consistency.py
+++ b/scripts/check_architecture_consistency.py
@@ -4,7 +4,7 @@ import os
 import sys
 from pathlib import Path
 
-ARCH_PATH = Path("docs/1_architecture/SIGMA_Architecture_v1.4.md")
+ARCH_PATH = Path("docs/1_architecture/SIGMA_Architecture_v1.2.md")
 SPEC_ROOT = Path("docs/4_development/module_specs")
 SRC_ROOT = Path("src/sigma")
 

--- a/scripts/check_architecture_consistency_ast.py
+++ b/scripts/check_architecture_consistency_ast.py
@@ -5,7 +5,7 @@ import sys
 import ast
 from pathlib import Path
 
-ARCH_PATH = Path("docs/1_architecture/SIGMA_Architecture_v1.4.md")
+ARCH_PATH = Path("docs/1_architecture/SIGMA_Architecture_v1.2.md")
 SPEC_ROOT = Path("docs/4_development/module_specs")
 SRC_ROOT = Path("src/sigma")
 

--- a/scripts/check_architecture_consistency_ast_advanced.py
+++ b/scripts/check_architecture_consistency_ast_advanced.py
@@ -5,7 +5,7 @@ import sys
 import ast
 from pathlib import Path
 
-ARCH_PATH = Path("docs/1_architecture/SIGMA_Architecture_v1.4.md")
+ARCH_PATH = Path("docs/1_architecture/SIGMA_Architecture_v1.2.md")
 SPEC_ROOT = Path("docs/4_development/module_specs")
 SRC_ROOT = Path("src/sigma")
 


### PR DESCRIPTION
## Summary
- rename architecture documentation to v1.2
- update version heading and history
- adjust architecture consistency scripts

## Testing
- `python scripts/check_architecture_consistency.py`
- `python scripts/check_architecture_consistency_ast.py`
- `python scripts/check_architecture_consistency_ast_advanced.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sigma')*
- `pre-commit run --files scripts/check_architecture_consistency.py scripts/check_architecture_consistency_ast.py scripts/check_architecture_consistency_ast_advanced.py docs/1_architecture/SIGMA_Architecture_v1.2.md` *(fails: could not fetch black)*