### PR TITLE
Add diagram generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ pytest
 ## 시스템 명세
 `specs/sigma_system.yaml` 파일은 컨테이너와 컴포넌트, 그리고 데이터 흐름을 YAML 형식으로 기술합니다.
 자세한 구조 설명은 `docs/sigma_yaml_structure.md` 문서를 참고하세요.
+
+## 다이어그램 생성
+`scripts/generate_diagrams.py` 스크립트를 실행하면 YAML 명세를 바탕으로 Mermaid 문법의 다이어그램 파일이 `docs/sigma_system_diagram.mmd`에 저장됩니다.
+
+```bash
+/usr/bin/python3 scripts/generate_diagrams.py
+```
+

--- a/docs/sigma_system_diagram.mmd
+++ b/docs/sigma_system_diagram.mmd
@@ -1,0 +1,11 @@
+```mermaid
+flowchart TD
+subgraph main ['SIGMA-X 가동 환경']
+    data_collector['data_collector (service)']
+    trade_executor['trade_executor (service)']
+    redis['redis (database)']
+end
+    data_collector -->|rabbitmq| trade_executor
+    trade_executor -->|redis| redis
+```
+

--- a/docs/sigma_yaml_structure.md
+++ b/docs/sigma_yaml_structure.md
@@ -25,3 +25,4 @@ containers:
 - **flows**: 컴포넌트 간 데이터 이동 경로와 방식입니다.
 
 예시는 `specs/sigma_system.yaml`에서 확인할 수 있습니다.
+`scripts/generate_diagrams.py`를 실행하면 이 YAML 파일로부터 Mermaid 다이어그램(`docs/sigma_system_diagram.mmd`)을 생성할 수 있습니다.

--- a/requirements.txt
+++ b/requirements.txt
@@ -162,3 +162,5 @@ xmltodict==0.14.2
 yapf==0.43.0
 yarl==1.20.0
 yq==3.4.3
+mermaid-cli==10.2.4
+

--- a/scripts/generate_diagrams.py
+++ b/scripts/generate_diagrams.py
@@ -1,0 +1,27 @@
+import yaml
+from pathlib import Path
+
+
+def main():
+    spec_path = Path("specs/sigma_system.yaml")
+    with spec_path.open() as f:
+        spec = yaml.safe_load(f)
+
+    container = spec.get("containers", [])[0]
+    lines = ["```mermaid", "flowchart TD"]
+    lines.append(f"subgraph {container['name']} ['{container['description']}']")
+    for comp in container.get("components", []):
+        lines.append(f"    {comp['name']}['{comp['name']} ({comp['type']})']")
+    lines.append("end")
+
+    for flow in container.get("flows", []):
+        lines.append(f"    {flow['from']} -->|{flow['channel']}| {flow['to']}")
+    lines.append("```")
+
+    output_path = Path("docs/sigma_system_diagram.mmd")
+    output_path.write_text("\n".join(lines))
+    print(f"Mermaid diagram saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate `docs/sigma_system_diagram.mmd` from YAML spec
- document diagram generation workflow
- mention new script in yaml structure docs
- add `mermaid-cli` to requirements

## Testing
- `pytest -q`
- `black scripts/generate_diagrams.py`
- *(pre-commit and flake8 were unavailable in the environment)*