### PR TITLE
Add scaffold script and generated modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ pytest
 /usr/bin/python3 scripts/generate_diagrams.py
 ```
 
+## 스캐폴드 생성
+`scripts/scaffold.py` 스크립트는 `specs/sigma_system.yaml` 파일을 읽어
+`src/`와 `tests/` 디렉터리에 기본 모듈과 `pytest` 테스트 템플릿을 만듭니다.
+
+```bash
+/usr/bin/python3 scripts/scaffold.py
+```
+

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""YAML 정의를 읽어 기본 모듈과 테스트 파일을 생성하는 스크립트."""
+
+import argparse
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+def snake_to_camel(name: str) -> str:
+    return "".join(part.capitalize() for part in name.split("_"))
+
+
+def create_module(name: str, description: str = "") -> Path:
+    src_dir = Path("src")
+    src_dir.mkdir(exist_ok=True)
+    (src_dir / "__init__.py").touch(exist_ok=True)
+    module_path = src_dir / f"{name}.py"
+    if module_path.exists():
+        return module_path
+
+    class_name = snake_to_camel(name)
+    content = (
+        f"class {class_name}:\n"
+        f'    """{description}"""\n\n'
+        "    def run(self) -> None:\n"
+        "        pass\n"
+    )
+    module_path.write_text(content)
+    return module_path
+
+
+def create_test(name: str) -> Path:
+    tests_dir = Path("tests")
+    tests_dir.mkdir(exist_ok=True)
+    test_path = tests_dir / f"test_{name}.py"
+    if test_path.exists():
+        return test_path
+
+    class_name = snake_to_camel(name)
+    content = (
+        f"from src.{name} import {class_name}\n\n\n"
+        f"def test_{name}_run():\n"
+        f"    obj = {class_name}()\n"
+        "    assert obj.run() is None\n"
+    )
+    test_path.write_text(content)
+    return test_path
+
+
+def format_files(*paths: Path) -> None:
+    files = [str(p) for p in paths if p.exists()]
+    if files:
+        subprocess.run(["black", *files], check=False)
+
+
+def generate(spec_path: Path) -> None:
+    with spec_path.open() as f:
+        spec = yaml.safe_load(f)
+
+    for container in spec.get("containers", []):
+        for comp in container.get("components", []):
+            mod = create_module(comp["name"], comp.get("description", ""))
+            test = create_test(comp["name"])
+            format_files(mod, test)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="모듈 스캐폴드 생성기")
+    parser.add_argument(
+        "yaml_path",
+        nargs="?",
+        default="specs/sigma_system.yaml",
+        help="YAML 경로",
+    )
+    args = parser.parse_args()
+    generate(Path(args.yaml_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_collector.py
+++ b/src/data_collector.py
@@ -1,0 +1,5 @@
+class DataCollector:
+    """"""
+
+    def run(self) -> None:
+        pass

--- a/src/redis.py
+++ b/src/redis.py
@@ -1,0 +1,5 @@
+class Redis:
+    """"""
+
+    def run(self) -> None:
+        pass

--- a/src/trade_executor.py
+++ b/src/trade_executor.py
@@ -1,0 +1,5 @@
+class TradeExecutor:
+    """"""
+
+    def run(self) -> None:
+        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_data_collector.py
+++ b/tests/test_data_collector.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))  # noqa: E402
+
+from src.data_collector import DataCollector  # noqa: E402
+
+
+def test_data_collector_run():
+    obj = DataCollector()
+    assert obj.run() is None

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))  # noqa: E402
+
+from src.redis import Redis  # noqa: E402
+
+
+def test_redis_run():
+    obj = Redis()
+    assert obj.run() is None

--- a/tests/test_trade_executor.py
+++ b/tests/test_trade_executor.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))  # noqa: E402
+
+from src.trade_executor import TradeExecutor  # noqa: E402
+
+
+def test_trade_executor_run():
+    obj = TradeExecutor()
+    assert obj.run() is None


### PR DESCRIPTION
## Summary
- 자동 스캐폴드 생성 스크립트 `scripts/scaffold.py` 추가
- 시스템 YAML을 기반으로 기본 모듈과 테스트 생성 기능 구현
- README에 스크립트 사용법 문서화
- 예시 모듈 및 테스트 파일 생성

## Testing
- `flake8 scripts/scaffold.py src tests`
- `black scripts/scaffold.py src tests`
- `pytest -q`