### PR TITLE
Add automatic script execution in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,34 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Detect YAML changes
+      id: yaml
+      run: |
+        if git diff --name-only HEAD^ | grep -E '\.ya?ml$'; then
+          echo "changed=true" >> $GITHUB_OUTPUT
+        else
+          echo "changed=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Generate diagrams
+      if: steps.yaml.outputs.changed == 'true'
+      run: |
+        python scripts/generate_diagrams.py
+
+    - name: Run scaffold
+      if: steps.yaml.outputs.changed == 'true'
+      run: |
+        python scripts/scaffold.py
+
+    - name: Generate docs
+      if: steps.yaml.outputs.changed == 'true'
+      run: |
+        python scripts/generate_docs.py
+
+    - name: Check generated files committed
+      if: steps.yaml.outputs.changed == 'true'
+      run: git diff --exit-code
+
     - name: Run tests
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ pytest
 mkdocs build
 ```
 
+## CI 자동 실행
+`specs/` 디렉터리의 YAML 파일을 수정하면 GitHub Actions가 자동으로 세 가지 스크립트
+(`generate_diagrams.py`, `scaffold.py`, `generate_docs.py`)을 실행합니다. 실행 결과
+생성된 파일이 커밋에 반영되어 있지 않으면 워크플로우가 실패하므로, YAML 변경 시 해당
+파일들을 함께 커밋해야 합니다. 이후 모든 테스트가 실행되어 통과해야 합니다.
+


### PR DESCRIPTION
## Summary
- execute diagram, scaffold, and docs generation scripts in CI
- run scripts only when YAML files change and verify no diff
- document new CI behavior in README

## Testing
- `pre-commit` *(failed: couldn't access network)*
- `pytest -q`