### PR TITLE
Add example spec and scaffold test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pytest
 ## 스캐폴드 생성
 `scripts/scaffold.py` 스크립트는 `specs/sigma_system.yaml` 파일을 읽어
 `src/`와 `tests/` 디렉터리에 기본 모듈과 `pytest` 테스트 템플릿을 만듭니다.
+간단한 동작 예시는 `specs/example.yaml` 파일을 활용해 확인할 수 있습니다.
 
 ```bash
 /usr/bin/python3 scripts/scaffold.py

--- a/docs/sigma_yaml_structure.md
+++ b/docs/sigma_yaml_structure.md
@@ -26,3 +26,4 @@ containers:
 
 예시는 `specs/sigma_system.yaml`에서 확인할 수 있습니다.
 `scripts/generate_diagrams.py`를 실행하면 이 YAML 파일로부터 Mermaid 다이어그램(`docs/sigma_system_diagram.mmd`)을 생성할 수 있습니다.
+추가로 `specs/example.yaml`에는 스캐폴드 동작을 확인할 수 있는 간단한 예제가 포함되어 있습니다.

--- a/specs/example.yaml
+++ b/specs/example.yaml
@@ -1,0 +1,16 @@
+# 테스트용 예제 시스템 정의
+containers:
+  - name: demo
+    description: 테스트 컨테이너
+    components:
+      - name: foo_service
+        type: service
+        description: 예제 서비스
+      - name: bar_db
+        type: database
+        description: 예제 데이터베이스
+    flows:
+      - from: foo_service
+        to: bar_db
+        channel: direct
+        description: "서비스에서 데이터베이스로 직접 저장"

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import yaml
+
+from scripts.scaffold import generate
+
+
+def test_scaffold(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    spec_path = repo_root / "specs" / "example.yaml"
+    with spec_path.open() as f:
+        spec = yaml.safe_load(f)
+
+    monkeypatch.chdir(tmp_path)
+    generate(spec_path)
+
+    for container in spec.get("containers", []):
+        for comp in container.get("components", []):
+            module_file = tmp_path / "src" / f"{comp['name']}.py"
+            test_file = tmp_path / "tests" / f"test_{comp['name']}.py"
+            assert module_file.exists()
+            assert test_file.exists()


### PR DESCRIPTION
## Summary
- add `specs/example.yaml` for scaffold demonstration
- document new example file in README and YAML docs
- test scaffold generation using the example YAML

## Testing
- `pytest -q`
- `pre-commit run --files tests/test_scaffold.py specs/example.yaml docs/sigma_yaml_structure.md README.md` *(fails: couldn't access github.com)*