### PR TITLE
Add diagram generation documentation and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
         python scripts/generate_diagrams.py
 
     - name: Build diagram images
-      if: steps.yaml.outputs.changed == 'true'
       run: |
         bash docs/scripts/gen_diagrams.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,8 @@ sudo apt install -y graphviz
 - 4.파일이나 문서를 수정하면 항상 연관문서들을 최신으로 업데이트 하세요
 - 5.추가로 앞으로 작업에 필요하고 유용한 의존성이 있다면requirements.txt에 추가하세요
 - 6.`docs/scripts/gen_diagrams.sh` 스크립트로 모든 다이어그램을 갱신하세요
+  루트 디렉터리에서 아래 명령을 실행하면 `.mmd`와 `.dot` 파일이 모두 SVG로 변환됩니다.
+  ```bash
+  bash docs/scripts/gen_diagrams.sh
+  ```
+  CI에서도 이 스크립트가 자동으로 실행되므로 문서 수정 후 반드시 실행 결과를 커밋하세요.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ pytest
 
 ## 다이어그램 생성
 `scripts/generate_diagrams.py`를 실행하면 YAML 명세를 바탕으로 `docs/sigma_system_diagram.mmd` 파일이 생성됩니다.
-이후 `docs/scripts/gen_diagrams.sh` 스크립트를 사용하여 모든 `.mmd`, `.dot` 파일을 SVG로 변환할 수 있습니다.
+`docs/scripts/gen_diagrams.sh` 스크립트는 mermaid-cli(mmdc)와 graphviz(dot)를 이용해
+`docs` 디렉터리의 모든 `.mmd`, `.dot` 파일을 일괄적으로 SVG로 변환합니다.
+CI 환경에서도 자동으로 실행되므로, 로컬에서도 아래와 같이 실행해 최신 다이어그램을 확인할 수 있습니다.
 
 필요 패키지 설치 예시:
 


### PR DESCRIPTION
## Summary
- document how to run the diagram generation script
- note diagram generation in AGENTS instructions
- call diagram builder unconditionally in CI
- regenerate diagram SVGs

## Testing
- `pre-commit run --files README.md AGENTS.md .github/workflows/ci.yml docs/1_architecture/c2_container.svg docs/1_architecture/c3_api.svg docs/1_architecture/c4_bot.svg docs/sigma_system_diagram.svg` *(fails: Could not fetch pre-commit hooks)*
- `pytest -q`