### PR TITLE
Add async data pipeline with Redis and strategy tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,27 @@ pip install -r requirements.txt
 ```
 
 ## 사용 방법
-현재 기본 코드베이스는 템플릿 형태로 제공되며, 각 모듈은 사용자의 전략에 맞게 확장할 수 있습니다. 구체적인 사용 예시는 추후 문서를 통해 제공될 예정입니다.
+기본적으로 `DataCollector`와 `TradeExecutor`는 비동기로 동작합니다. 아래와 같이 실행해 볼 수 있습니다.
+
+```python
+import asyncio
+from src.data_collector import DataCollector
+from src.trade_executor import TradeExecutor
+
+
+async def main():
+    collector = DataCollector()
+    executor = TradeExecutor()
+    await asyncio.gather(
+        collector.run(limit=5),
+        executor.run(limit=5),
+    )
+
+
+asyncio.run(main())
+```
+
+모듈은 사용자의 전략에 맞게 자유롭게 확장할 수 있습니다.
 
 ## 빌드 및 테스트
 별도의 빌드 단계는 없으며 다음 명령으로 테스트를 실행할 수 있습니다.

--- a/docs/components.md
+++ b/docs/components.md
@@ -4,6 +4,12 @@
 
 | 이름 | 타입 | 이미지 | 설명 |
 | --- | --- | --- | --- |
-| data_collector | service | docker.io/sigma/data_collector:latest | 시세 데이터를 수집하는 모듈.  외부 거래소나 데이터 소스에서 시세 정보를 받아 다른 컴포넌트로 전달합니다.  예시: <br> ````python<br>collector = DataCollector()<br>collector.run()<br>```` |
-| trade_executor | service | docker.io/sigma/trade_executor:latest | 매매 로직을 실행하는 컴포넌트.  수집된 시세 데이터를 바탕으로 주문을 생성하고, 필요한 경우 결과를 저장합니다.  예시: <br> ````python<br>executor = TradeExecutor()<br>executor.run()<br>```` |
+| data_collector | service | docker.io/sigma/data_collector:latest | 비동기 WebSocket 연결을 통해 시세 데이터를 수신하고 Redis 채널로 발행합니다.  예시: <br> ````python
+collector = DataCollector()
+await collector.run()
+```` |
+| trade_executor | service | docker.io/sigma/trade_executor:latest | Redis 채널을 구독해 이동평균 교차 전략을 실행하고 주문 결과를 저장합니다.  예시: <br> ````python
+executor = TradeExecutor()
+await executor.run()
+```` |
 | redis | database | docker.io/library/redis:7 | 애플리케이션용 Redis 인터페이스.  키-값 저장소인 Redis와의 연결을 관리하며 데이터 읽기와 쓰기를 담당합니다.  예시: <br> ````python<br>store = Redis()<br>store.run()<br>```` |

--- a/src/data_collector.py
+++ b/src/data_collector.py
@@ -36,6 +36,6 @@ class DataCollector:
                         received += 1
                         if limit and received >= limit:
                             return
-            except websockets.WebSocketException:
+            except (websockets.WebSocketException, OSError):
                 await asyncio.sleep(1)
 

--- a/src/data_collector.py
+++ b/src/data_collector.py
@@ -1,12 +1,41 @@
+import asyncio
+from typing import Optional
+
+import websockets
+
+
 class DataCollector:
     """시세 데이터를 수집하는 모듈.
 
-    외부 거래소나 데이터 소스에서 시세 정보를 받아 다른 컴포넌트로 전달합니다.
+    외부 거래소나 데이터 소스에서 시세 정보를 받아 Redis 채널로 전달합니다.
 
     예시:
         >>> collector = DataCollector()
-        >>> collector.run()
+        >>> await collector.run()
     """
 
-    def run(self) -> None:
-        pass
+    def __init__(self, url: str = "ws://localhost:8765", *, redis_client=None, channel: str = "ticks") -> None:
+        self.url = url
+        self.redis = redis_client
+        self.channel = channel
+
+    async def run(self, limit: Optional[int] = None) -> None:
+        """WebSocket에서 데이터를 읽어 Redis 채널로 발행한다."""
+
+        if self.redis is None:
+            import redis.asyncio as redis
+
+            self.redis = redis.from_url("redis://localhost")
+
+        received = 0
+        while True:
+            try:
+                async with websockets.connect(self.url) as ws:
+                    async for message in ws:
+                        await self.redis.publish(self.channel, message)
+                        received += 1
+                        if limit and received >= limit:
+                            return
+            except websockets.WebSocketException:
+                await asyncio.sleep(1)
+

--- a/src/trade_executor.py
+++ b/src/trade_executor.py
@@ -1,12 +1,67 @@
+import asyncio
+from typing import Optional
+
+
 class TradeExecutor:
     """매매 로직을 실행하는 컴포넌트.
 
-    수집된 시세 데이터를 바탕으로 주문을 생성하고, 필요한 경우 결과를 저장합니다.
+    수집된 시세 데이터를 바탕으로 이동평균 교차 전략을 수행하고 주문 결과를 Redis에 저장합니다.
 
     예시:
         >>> executor = TradeExecutor()
-        >>> executor.run()
+        >>> await executor.run()
     """
 
-    def run(self) -> None:
-        pass
+    def __init__(
+        self,
+        *,
+        redis_client=None,
+        channel: str = "ticks",
+        order_key: str = "orders",
+        short_window: int = 3,
+        long_window: int = 5,
+    ) -> None:
+        self.redis = redis_client
+        self.channel = channel
+        self.order_key = order_key
+        self.short_window = short_window
+        self.long_window = long_window
+        self.prices: list[float] = []
+
+    async def run(self, limit: Optional[int] = None) -> None:
+        """Redis 채널을 구독해 주문 로직을 수행한다."""
+
+        if self.redis is None:
+            import redis.asyncio as redis
+
+            self.redis = redis.from_url("redis://localhost")
+
+        pubsub = self.redis.pubsub()
+        await pubsub.subscribe(self.channel)
+
+        processed = 0
+        try:
+            async for message in pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                price = float(message["data"])
+                self.prices.append(price)
+                if len(self.prices) > self.long_window:
+                    self.prices.pop(0)
+
+                if len(self.prices) >= self.long_window:
+                    short_ma = sum(self.prices[-self.short_window :]) / self.short_window
+                    long_ma = sum(self.prices) / self.long_window
+                    if short_ma > long_ma:
+                        await self.redis.rpush(self.order_key, "BUY")
+                    elif short_ma < long_ma:
+                        await self.redis.rpush(self.order_key, "SELL")
+                    else:
+                        await self.redis.rpush(self.order_key, "HOLD")
+
+                processed += 1
+                if limit and processed >= limit:
+                    break
+        finally:
+            await pubsub.unsubscribe(self.channel)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,53 @@
+import asyncio
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+class FakePubSub:
+    def __init__(self, redis, channel: str):
+        self.redis = redis
+        self.channel = channel
+        self.queue: asyncio.Queue = asyncio.Queue()
+
+    async def subscribe(self, channel: str) -> None:
+        self.redis.subscribers.setdefault(channel, []).append(self.queue)
+
+    async def unsubscribe(self, channel: str) -> None:
+        if channel in self.redis.subscribers:
+            self.redis.subscribers[channel].remove(self.queue)
+
+    async def listen(self):
+        while True:
+            data = await self.queue.get()
+            yield {"type": "message", "data": data}
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.channels: dict[str, list[str]] = {}
+        self.subscribers: dict[str, list[asyncio.Queue]] = {}
+        self.lists: dict[str, list[str]] = {}
+
+    async def publish(self, channel: str, message: str) -> None:
+        self.channels.setdefault(channel, []).append(message)
+        for q in self.subscribers.get(channel, []):
+            await q.put(message)
+
+    def pubsub(self) -> FakePubSub:
+        return FakePubSub(self, "")
+
+    async def rpush(self, key: str, value: str) -> None:
+        self.lists.setdefault(key, []).append(value)
+
+    async def lrange(self, key: str, start: int, end: int):
+        end = None if end == -1 else end + 1
+        return self.lists.get(key, [])[start:end]
+
+
+@pytest.fixture
+def fake_redis():
+    return FakeRedis()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
 class FakePubSub:
-    def __init__(self, redis, channel: str):
+    def __init__(self, redis):
         self.redis = redis
-        self.channel = channel
         self.queue: asyncio.Queue = asyncio.Queue()
 
     async def subscribe(self, channel: str) -> None:

--- a/tests/test_data_collector.py
+++ b/tests/test_data_collector.py
@@ -1,12 +1,28 @@
+import asyncio
 import sys
 from pathlib import Path
 
+import pytest
+import websockets
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT_DIR))  # noqa: E402
+sys.path.insert(0, str(ROOT_DIR))
 
-from src.data_collector import DataCollector  # noqa: E402
+from src.data_collector import DataCollector
 
 
-def test_data_collector_run():
-    obj = DataCollector()
-    assert obj.run() is None
+@pytest.mark.asyncio
+async def test_data_collector_run(fake_redis):
+    messages = ["1", "2", "3"]
+
+    async def handler(ws):
+        for msg in messages:
+            await ws.send(msg)
+        await ws.close()
+
+    server = await websockets.serve(handler, "localhost", 8765)
+    async with server:
+        collector = DataCollector(url="ws://localhost:8765", redis_client=fake_redis)
+        await collector.run(limit=len(messages))
+
+    assert fake_redis.channels["ticks"] == messages


### PR DESCRIPTION
## Summary
- implement async websocket collector publishing to Redis
- implement trade executor subscribing from Redis and running SMA strategy
- document async usage and update component descriptions
- provide fake Redis utilities and async tests
- regenerate diagrams

## Testing
- `venv/bin/python -m pytest -q`
