### PR TITLE
Implement analytics backtesting modules

### DIFF
--- a/docs/backtest_guide.md
+++ b/docs/backtest_guide.md
@@ -3,7 +3,7 @@
 이 문서는 SIGMA-X에서 백테스트 모드를 실행하는 기본 절차를 설명합니다.
 
 ## 1. 준비
-- `DataCollector`와 `TradeExecutor` 모듈이 설치되어 있어야 합니다.
+- `HistoricalDataLoader`, `StrategyTester`, `SimulatorExecutor`, `PerformanceReporter` 모듈이 설치되어 있어야 합니다.
 - 과거 데이터는 CSV 파일이나 데이터베이스에서 가져올 수 있습니다.
 
 ## 2. 실행 방법
@@ -11,19 +11,23 @@
 
 ```python
 import asyncio
-from src.data_collector import DataCollector
-from src.trade_executor import TradeExecutor
+from src.historical_data_loader import HistoricalDataLoader
+from src.strategy_tester import StrategyTester
+from src.simulator_executor import SimulatorExecutor
+from src.performance_reporter import PerformanceReporter
 
 async def main():
-    collector = DataCollector(url="ws://localhost:8765")
-    executor = TradeExecutor()
-    await asyncio.gather(
-        collector.run(limit=100),
-        executor.run(limit=100),
-    )
+    loader = HistoricalDataLoader("prices.csv")
+    tester = StrategyTester()
+    simulator = SimulatorExecutor()
+    reporter = PerformanceReporter()
 
-asyncio.run(main())
+    async for signal, price in tester.run(loader.load()):
+        await simulator.execute(signal, price)
+
+    print("profit", reporter.report(simulator.orders))
 ```
+데이터베이스에 저장된 주문 기록과 결과 테이블을 조회해 전략 성과를 확인합니다.
 
 - `limit` 값은 처리할 메시지 수를 제한합니다.
 - 시세 데이터는 RabbitMQ 큐를 거쳐 처리되며, 결과 주문 내역은 PostgreSQL `orders` 테이블에도 기록됩니다.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,6 +2,11 @@ from .redis_client import Redis
 from .data_collector import DataCollector
 from .trade_executor import TradeExecutor
 from .rabbitmq_client import RabbitMQ
+from .api_server import APIServer
+from .historical_data_loader import HistoricalDataLoader
+from .strategy_tester import StrategyTester
+from .simulator_executor import SimulatorExecutor
+from .performance_reporter import PerformanceReporter
 
 __all__ = [
     "Redis",
@@ -9,4 +14,8 @@ __all__ = [
     "TradeExecutor",
     "RabbitMQ",
     "APIServer",
+    "HistoricalDataLoader",
+    "StrategyTester",
+    "SimulatorExecutor",
+    "PerformanceReporter",
 ]

--- a/src/database.py
+++ b/src/database.py
@@ -32,4 +32,6 @@ def init_db(url: str | None = None) -> Session:
     db_url = url or DATABASE_URL
     eng = create_engine(db_url)
     Base.metadata.create_all(eng)
-    return sessionmaker(bind=eng)()
+    global SessionLocal
+    SessionLocal = sessionmaker(bind=eng)
+    return SessionLocal()

--- a/src/historical_data_loader.py
+++ b/src/historical_data_loader.py
@@ -1,0 +1,20 @@
+import os
+from typing import AsyncIterator
+
+
+class HistoricalDataLoader:
+    """과거 시세 데이터를 순차적으로 로드하는 간단한 로더."""
+
+    def __init__(self, source: str | None = None) -> None:
+        self.source = source or os.getenv("SIGMA_HISTORY_CSV", "history.csv")
+
+    async def load(self) -> AsyncIterator[float]:
+        """CSV 파일에서 가격을 비동기적으로 읽어 들인다."""
+        if not os.path.exists(self.source):
+            return
+        with open(self.source) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                yield float(line)

--- a/src/performance_reporter.py
+++ b/src/performance_reporter.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+
+class PerformanceReporter:
+    """단순 수익률을 계산해 DB에 기록한다."""
+
+    def __init__(self, db_session=None) -> None:
+        self.db = db_session
+
+    def calculate_profit(
+        self,
+        orders: Iterable[dict[str, float | str]],
+    ) -> float:
+        profit = 0.0
+        position: float | None = None
+        for order in orders:
+            side = order["side"]
+            price = float(order["price"])
+            if side == "BUY":
+                position = price
+            elif side == "SELL" and position is not None:
+                profit += price - position
+                position = None
+        return profit
+
+    def report(self, orders: Iterable[dict[str, float | str]]) -> float:
+        profit = self.calculate_profit(orders)
+        if self.db is not None:
+            from .database import BacktestResult
+
+            self.db.add(BacktestResult(profit=profit))
+            self.db.commit()
+        return profit

--- a/src/simulator_executor.py
+++ b/src/simulator_executor.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+
+class SimulatorExecutor:
+    """가상 체결을 수행하는 간단한 시뮬레이터."""
+
+    def __init__(self, db_session=None) -> None:
+        self.db = db_session
+        self.orders: list[dict[str, float | str]] = []
+
+    async def execute(self, signal: str, price: float) -> None:
+        if signal in ("BUY", "SELL"):
+            self.orders.append({"side": signal, "price": price})
+            if self.db is not None:
+                from .database import Order
+
+                self.db.add(Order(side=signal, price=price))
+                self.db.commit()
+
+    async def run(self, stream: Iterable[tuple[str, float]]) -> None:
+        for signal, price in stream:
+            await self.execute(signal, price)

--- a/src/strategy_tester.py
+++ b/src/strategy_tester.py
@@ -1,0 +1,32 @@
+from typing import AsyncIterator
+
+
+class StrategyTester:
+    """단순 이동평균 교차 전략을 테스트하는 컴포넌트."""
+
+    def __init__(self, short_window: int = 3, long_window: int = 5) -> None:
+        self.short_window = short_window
+        self.long_window = long_window
+        self.prices: list[float] = []
+
+    async def process_price(self, price: float) -> str:
+        self.prices.append(price)
+        if len(self.prices) > self.long_window:
+            self.prices.pop(0)
+        if len(self.prices) >= self.long_window:
+            short_slice = self.prices[-self.short_window :]  # noqa: E203
+            short_ma = sum(short_slice) / self.short_window
+            long_ma = sum(self.prices) / self.long_window
+            if short_ma > long_ma:
+                return "BUY"
+            if short_ma < long_ma:
+                return "SELL"
+            return "HOLD"
+        return "HOLD"
+
+    async def run(
+        self, prices: AsyncIterator[float]
+    ) -> AsyncIterator[tuple[str, float]]:
+        async for price in prices:
+            signal = await self.process_price(price)
+            yield signal, price

--- a/tests/test_backtest_modules.py
+++ b/tests/test_backtest_modules.py
@@ -1,0 +1,45 @@
+import pytest
+
+from src.historical_data_loader import HistoricalDataLoader
+from src.strategy_tester import StrategyTester
+from src.simulator_executor import SimulatorExecutor
+from src.performance_reporter import PerformanceReporter
+from src.database import Base, Order, BacktestResult
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.mark.asyncio
+async def test_historical_loader(tmp_path):
+    csv = tmp_path / "prices.csv"
+    csv.write_text("1\n2\n3\n")
+    loader = HistoricalDataLoader(str(csv))
+    data = [p async for p in loader.load()]
+    assert data == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.asyncio
+async def test_backtest_pipeline(tmp_path):
+    csv = tmp_path / "prices.csv"
+    csv.write_text("1\n2\n3\n4\n5\n4\n3\n2\n1\n")
+
+    engine = create_engine(f"sqlite:///{tmp_path}/t.db")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    loader = HistoricalDataLoader(str(csv))
+    tester = StrategyTester(short_window=2, long_window=3)
+    simulator = SimulatorExecutor(db_session=session)
+    reporter = PerformanceReporter(db_session=session)
+
+    async for signal, price in tester.run(loader.load()):
+        await simulator.execute(signal, price)
+
+    profit = reporter.report(simulator.orders)
+
+    orders = session.query(Order).all()
+    result = session.query(BacktestResult).one()
+
+    assert len(orders) == len(simulator.orders)
+    assert result.profit == pytest.approx(profit)


### PR DESCRIPTION
## Summary
- implement HistoricalDataLoader to read past prices
- create StrategyTester for MA crossover signals
- add SimulatorExecutor and PerformanceReporter
- refactor TradeExecutor to reuse `_save_order`
- fix unused SessionLocal and update documentation
- add tests for analytics pipeline
- regenerate diagrams

## Testing
- `pre-commit run --files src/historical_data_loader.py src/strategy_tester.py src/simulator_executor.py src/performance_reporter.py src/__init__.py src/trade_executor.py src/database.py docs/backtest_guide.md tests/test_backtest_modules.py`
- `pytest -q`