### PR TITLE
Restructure bot modules

### DIFF
--- a/docs/1_architecture/class_diagram.mmd
+++ b/docs/1_architecture/class_diagram.mmd
@@ -5,7 +5,19 @@ classDiagram
     }
     class TradeExecutor {
         +run(limit)
-        +process_price(price)
+    }
+    class MovingAverageStrategy {
+        +process(price)
+    }
+    class RiskManager {
+        +check(signal)
+        +apply(signal)
+    }
+    class OrderExecutor {
+        +execute(signal, price)
+    }
+    class SimulatorExecutor {
+        +execute(signal, price)
     }
     class APIServer {
         +app FastAPI
@@ -18,7 +30,10 @@ classDiagram
 
     DataCollector --> RabbitMQ : publish
     TradeExecutor --> RabbitMQ : consume
-    TradeExecutor --> Redis : write
+    TradeExecutor --> MovingAverageStrategy : use
+    TradeExecutor --> RiskManager : use
+    TradeExecutor --> OrderExecutor : use
+    OrderExecutor --> SimulatorExecutor : delegate
+    OrderExecutor --> Redis : write
     APIServer --> Redis : read/write
 ```
-

--- a/docs/components.md
+++ b/docs/components.md
@@ -8,7 +8,7 @@
 collector = DataCollector()
 await collector.run()
 ``` |
-| trade_executor | service | docker.io/sigma/trade_executor:latest | RabbitMQ 큐에서 데이터를 가져와 이동평균 교차 전략을 실행하고 주문 결과를 Redis에 저장합니다. 예시:<br>```python
+| trade_executor | service | docker.io/sigma/trade_executor:latest | RabbitMQ 큐에서 데이터를 가져와 전략(`MovingAverageStrategy` 등)을 실행하고 `RiskManager` 검증 후 `OrderExecutor`를 통해 주문을 처리합니다. 예시:<br>```python
 executor = TradeExecutor()
 await executor.run()
 ``` |

--- a/docs/strategy_guide.md
+++ b/docs/strategy_guide.md
@@ -3,29 +3,26 @@
 새로운 매매 전략을 SIGMA-X에 통합하는 방법을 설명합니다.
 
 ## 1. 전략 모듈 작성
-`src/` 디렉터리에 전략 클래스를 정의합니다. 예시:
+`src/` 디렉터리에 `BaseStrategy`를 상속한 클래스를 정의합니다. 예시:
 
 ```python
-class MyStrategy:
+from src.strategy import BaseStrategy
+
+class MyStrategy(BaseStrategy):
     async def process(self, price: float) -> str:
         # 여기서 매매 로직을 구현합니다.
         return "HOLD"
 ```
 
-## 2. TradeExecutor 확장
-`TradeExecutor`를 상속하거나 `process_price` 메서드를 오버라이드하여 작성한 전략을 사용합니다.
+## 2. TradeExecutor에 주입
+`TradeExecutor` 생성 시 `strategy` 인자로 전달해 사용합니다.
 
 ```python
 from src.trade_executor import TradeExecutor
 from src.my_strategy import MyStrategy
 
-class CustomExecutor(TradeExecutor):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.strategy = MyStrategy()
-
-    async def process_price(self, price: float) -> str:
-        return await self.strategy.process(price)
+executor = TradeExecutor(strategy=MyStrategy())
+await executor.run()
 ```
 
 ## 3. 테스트 추가

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,6 +7,9 @@ from .historical_data_loader import HistoricalDataLoader
 from .strategy_tester import StrategyTester
 from .simulator_executor import SimulatorExecutor
 from .performance_reporter import PerformanceReporter
+from .risk_manager import RiskManager
+from .order_executor import OrderExecutor
+from .strategy import BaseStrategy, MovingAverageStrategy
 
 __all__ = [
     "Redis",
@@ -18,4 +21,8 @@ __all__ = [
     "StrategyTester",
     "SimulatorExecutor",
     "PerformanceReporter",
+    "RiskManager",
+    "OrderExecutor",
+    "BaseStrategy",
+    "MovingAverageStrategy",
 ]

--- a/src/order_executor.py
+++ b/src/order_executor.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+
+class OrderExecutor:
+    """주문 실행을 담당한다."""
+
+    def __init__(self, redis_client=None, order_key: str = "orders", simulator=None, db_session=None) -> None:
+        self.redis = redis_client
+        self.order_key = order_key
+        self.simulator = simulator
+        self.db = db_session
+
+    async def _save_db(self, signal: str, price: float) -> None:
+        if self.db is not None:
+            from .database import Order
+
+            self.db.add(Order(side=signal, price=price))
+            self.db.commit()
+
+    async def execute(self, signal: str, price: float) -> None:
+        if self.simulator is not None:
+            await self.simulator.execute(signal, price)
+        else:
+            await self._save_db(signal, price)
+        if self.redis is not None:
+            await self.redis.rpush(self.order_key, signal)

--- a/src/risk_manager.py
+++ b/src/risk_manager.py
@@ -1,0 +1,19 @@
+class RiskManager:
+    """간단한 포지션 기반 리스크 관리기."""
+
+    def __init__(self, max_position: int = 100) -> None:
+        self.position = 0
+        self.max_position = max_position
+
+    def check(self, signal: str) -> bool:
+        if signal == "BUY" and self.position >= self.max_position:
+            return False
+        if signal == "SELL" and self.position <= 0:
+            return False
+        return True
+
+    def apply(self, signal: str) -> None:
+        if signal == "BUY":
+            self.position += 1
+        elif signal == "SELL":
+            self.position -= 1

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseStrategy(ABC):
+    """추상 전략 클래스."""
+
+    @abstractmethod
+    async def process(self, price: float) -> str:
+        """가격을 입력받아 주문 신호를 반환한다."""
+        raise NotImplementedError
+
+
+class MovingAverageStrategy(BaseStrategy):
+    """단순 이동평균 교차 전략."""
+
+    def __init__(self, short_window: int = 3, long_window: int = 5) -> None:
+        self.short_window = short_window
+        self.long_window = long_window
+        self.prices: list[float] = []
+
+    async def process(self, price: float) -> str:
+        self.prices.append(price)
+        if len(self.prices) > self.long_window:
+            self.prices.pop(0)
+        if len(self.prices) >= self.long_window:
+            short_ma = sum(self.prices[-self.short_window :]) / self.short_window
+            long_ma = sum(self.prices) / self.long_window
+            if short_ma > long_ma:
+                return "BUY"
+            if short_ma < long_ma:
+                return "SELL"
+        return "HOLD"

--- a/tests/test_risk_order.py
+++ b/tests/test_risk_order.py
@@ -1,0 +1,27 @@
+import asyncio
+
+import pytest
+
+from src.order_executor import OrderExecutor
+from src.risk_manager import RiskManager
+from src.simulator_executor import SimulatorExecutor
+
+
+@pytest.mark.asyncio
+async def test_risk_manager():
+    rm = RiskManager(max_position=1)
+    assert rm.check("BUY") is True
+    rm.apply("BUY")
+    assert rm.check("BUY") is False
+    assert rm.check("SELL") is True
+    rm.apply("SELL")
+    assert rm.position == 0
+
+
+@pytest.mark.asyncio
+async def test_order_executor(fake_redis):
+    sim = SimulatorExecutor()
+    executor = OrderExecutor(redis_client=fake_redis, simulator=sim)
+    await executor.execute("BUY", 10)
+    assert fake_redis.lists["orders"] == ["BUY"]
+    assert sim.orders[0]["side"] == "BUY"


### PR DESCRIPTION
## Summary
- separate risk manager and order executor modules
- add pluggable strategy base class and moving average strategy
- update trade executor to use new components
- document new bot architecture and usage
- add tests for risk manager and order executor

## Testing
- `pre-commit` *(fails: flake8 not found)*
- `pytest -q`