### PR TITLE
Add plugin-based StrategyManager

### DIFF
--- a/docs/1_architecture/class_diagram.mmd
+++ b/docs/1_architecture/class_diagram.mmd
@@ -6,6 +6,9 @@ classDiagram
     class TradeExecutor {
         +run(limit)
     }
+    class StrategyManager {
+        +change_strategy(name)
+    }
     class MovingAverageStrategy {
         +process(price)
     }
@@ -30,7 +33,8 @@ classDiagram
 
     DataCollector --> RabbitMQ : publish
     TradeExecutor --> RabbitMQ : consume
-    TradeExecutor --> MovingAverageStrategy : use
+    TradeExecutor --> StrategyManager : use
+    StrategyManager --> MovingAverageStrategy : manage
     TradeExecutor --> RiskManager : use
     TradeExecutor --> OrderExecutor : use
     OrderExecutor --> SimulatorExecutor : delegate

--- a/docs/admin_manual.md
+++ b/docs/admin_manual.md
@@ -27,9 +27,9 @@
 
 ## 4. API 관리 기능
 
-`/token` 엔드포인트에서 관리자 계정으로 토큰을 발급받으면 아래 API를 사용할 수 있습니다. 발급된 토큰은 기본적으로 15분 후 만료되며, 필요하다면 `APIServer` 생성 시 `token_expire_seconds` 값으로 조정할 수 있습니다. 만료된 토큰은 `/token` 엔드포인트를 통해 갱신해야 합니다.
+- `/token` 엔드포인트에서 관리자 계정으로 토큰을 발급받으면 아래 API를 사용할 수 있습니다. 발급된 토큰은 기본적으로 15분 후 만료되며, 필요하다면 `APIServer` 생성 시 `token_expire_seconds` 값으로 조정할 수 있습니다. 만료된 토큰은 `/token` 엔드포인트를 통해 갱신해야 합니다.
 
-- `/strategies` : 등록된 전략 목록 조회 및 수정
+- `/strategies` : `StrategyManager`가 인식한 전략 목록을 확인하고 실행 중인 전략을 교체
 - `/system/tasks` : 실행 중인 작업 확인
 - `/backtests` : 백테스트 결과 조회
 - `/notify` : 실시간 알림 전송. `message` 파라미터는 쿼리 문자열로 전달됩니다 (예: `/notify?message=Hello`). 전송된 알림은 WebSocket 구독자에게도 전달됩니다.

--- a/docs/components.md
+++ b/docs/components.md
@@ -8,7 +8,7 @@
 collector = DataCollector()
 await collector.run()
 ``` |
-| trade_executor | service | docker.io/sigma/trade_executor:latest | RabbitMQ 큐에서 데이터를 가져와 전략(`MovingAverageStrategy` 등)을 실행하고 `RiskManager` 검증 후 `OrderExecutor`를 통해 주문을 처리합니다. 실거래 모드에서는 업비트와 바이낸스 선물 API(`exchange_client`)를 통해 직접 주문을 발행합니다. 예시:<br>```python
+| trade_executor | service | docker.io/sigma/trade_executor:latest | RabbitMQ 큐에서 데이터를 가져와 `StrategyManager`에 등록된 전략을 실행하고 `RiskManager` 검증 후 `OrderExecutor`를 통해 주문을 처리합니다. 실거래 모드에서는 업비트와 바이낸스 선물 API(`exchange_client`)를 통해 직접 주문을 발행합니다. 예시:<br>```python
 executor = TradeExecutor()
 await executor.run()
 ``` |

--- a/docs/strategy_guide.md
+++ b/docs/strategy_guide.md
@@ -14,15 +14,15 @@ class MyStrategy(BaseStrategy):
         return "HOLD"
 ```
 
-## 2. TradeExecutor에 주입
-`TradeExecutor` 생성 시 `strategy` 인자로 전달해 사용합니다.
+## 2. 전략 등록 및 교체
+작성한 파일을 `src/strategies/` 디렉터리에 두면 `StrategyManager`가 자동으로 인식합니다.
+실행 중에는 다음과 같이 전략을 교체할 수 있습니다.
 
 ```python
-from src.trade_executor import TradeExecutor
-from src.my_strategy import MyStrategy
+from src.strategy_manager import StrategyManager
 
-executor = TradeExecutor(strategy=MyStrategy())
-await executor.run()
+manager = StrategyManager()
+manager.change_strategy("my_strategy")
 ```
 
 ## 3. 테스트 추가

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,6 +10,7 @@ from .performance_reporter import PerformanceReporter
 from .risk_manager import RiskManager
 from .order_executor import OrderExecutor
 from .strategy import BaseStrategy, MovingAverageStrategy
+from .strategy_manager import StrategyManager
 
 __all__ = [
     "Redis",
@@ -25,4 +26,5 @@ __all__ = [
     "OrderExecutor",
     "BaseStrategy",
     "MovingAverageStrategy",
+    "StrategyManager",
 ]

--- a/src/plugin_loader.py
+++ b/src/plugin_loader.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib
+import os
+from types import ModuleType
+from typing import Type
+
+from .strategy import BaseStrategy
+
+
+def _find_strategy_class(module: ModuleType) -> Type[BaseStrategy]:
+    """모듈에서 BaseStrategy 서브클래스를 탐색한다."""
+    for obj in module.__dict__.values():
+        if isinstance(obj, type) and issubclass(obj, BaseStrategy) and obj is not BaseStrategy:
+            return obj
+    raise ImportError("No strategy class found")
+
+
+def load_strategy(name: str, package: str = "src.strategies") -> BaseStrategy:
+    """지정한 이름의 전략 클래스를 로드해 인스턴스로 반환한다."""
+    module = importlib.import_module(f"{package}.{name}")
+    cls = _find_strategy_class(module)
+    return cls()
+
+
+def list_strategies(package: str = "src.strategies") -> list[str]:
+    """패키지 내 존재하는 전략 모듈 목록을 반환한다."""
+    spec = importlib.util.find_spec(package)
+    if spec is None or not spec.submodule_search_locations:
+        return []
+    directory = spec.submodule_search_locations[0]
+    result = []
+    for fname in os.listdir(directory):
+        if fname.startswith("_") or not fname.endswith(".py"):
+            continue
+        result.append(fname[:-3])
+    return sorted(result)

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,0 +1,3 @@
+from .moving_average import MovingAverageStrategy
+
+__all__ = ["MovingAverageStrategy"]

--- a/src/strategies/moving_average.py
+++ b/src/strategies/moving_average.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from ..strategy import BaseStrategy
+
+
+class MovingAverageStrategy(BaseStrategy):
+    """단순 이동평균 교차 전략."""
+
+    def __init__(self, short_window: int = 3, long_window: int = 5) -> None:
+        self.short_window = short_window
+        self.long_window = long_window
+        self.prices: list[float] = []
+
+    async def process(self, price: float) -> str:
+        self.prices.append(price)
+        if len(self.prices) > self.long_window:
+            self.prices.pop(0)
+        if len(self.prices) >= self.long_window:
+            short_ma = sum(self.prices[-self.short_window :]) / self.short_window
+            long_ma = sum(self.prices) / self.long_window
+            if short_ma > long_ma:
+                return "BUY"
+            if short_ma < long_ma:
+                return "SELL"
+        return "HOLD"

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -12,23 +12,10 @@ class BaseStrategy(ABC):
         raise NotImplementedError
 
 
-class MovingAverageStrategy(BaseStrategy):
-    """단순 이동평균 교차 전략."""
+# 기본 제공 전략은 strategies 패키지에서 불러와 재노출한다.
+try:
+    from .strategies.moving_average import MovingAverageStrategy
+except Exception:  # pragma: no cover - fallback if plugins missing
+    MovingAverageStrategy = None  # type: ignore
 
-    def __init__(self, short_window: int = 3, long_window: int = 5) -> None:
-        self.short_window = short_window
-        self.long_window = long_window
-        self.prices: list[float] = []
-
-    async def process(self, price: float) -> str:
-        self.prices.append(price)
-        if len(self.prices) > self.long_window:
-            self.prices.pop(0)
-        if len(self.prices) >= self.long_window:
-            short_ma = sum(self.prices[-self.short_window :]) / self.short_window
-            long_ma = sum(self.prices) / self.long_window
-            if short_ma > long_ma:
-                return "BUY"
-            if short_ma < long_ma:
-                return "SELL"
-        return "HOLD"
+__all__ = ["BaseStrategy", "MovingAverageStrategy"]

--- a/src/strategy_manager.py
+++ b/src/strategy_manager.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .strategy import BaseStrategy, MovingAverageStrategy
+from .plugin_loader import load_strategy, list_strategies
+
+
+class StrategyManager:
+    """전략 로딩과 교체를 담당한다."""
+
+    def __init__(self, initial: str = "moving_average") -> None:
+        self._strategies: Dict[str, BaseStrategy] = {}
+        self._current: BaseStrategy | None = None
+        self.change_strategy(initial)
+
+    def register(self, name: str, strategy: BaseStrategy) -> None:
+        self._strategies[name] = strategy
+
+    def current(self) -> BaseStrategy:
+        assert self._current is not None
+        return self._current
+
+    def available(self) -> list[str]:
+        return list_strategies()
+
+    def change_strategy(self, name: str) -> None:
+        if name not in self._strategies:
+            try:
+                strategy = load_strategy(name)
+            except Exception:
+                if name == "moving_average":
+                    strategy = MovingAverageStrategy()
+                else:
+                    raise
+            self.register(name, strategy)
+        self._current = self._strategies[name]

--- a/src/trade_executor.py
+++ b/src/trade_executor.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 from .order_executor import OrderExecutor
 from .risk_manager import RiskManager
-from .strategy import BaseStrategy, MovingAverageStrategy
+from .strategy import BaseStrategy
+from .strategy_manager import StrategyManager
 
 
 class TradeExecutor:
@@ -20,6 +21,7 @@ class TradeExecutor:
         queue: str | None = None,
         order_key: str | None = None,
         strategy: BaseStrategy | None = None,
+        strategy_manager: StrategyManager | None = None,
         risk_manager: RiskManager | None = None,
         order_executor: OrderExecutor | None = None,
         short_window: int | None = None,
@@ -35,7 +37,21 @@ class TradeExecutor:
         self.order_key = order_key or os.getenv("SIGMA_ORDER_KEY", "orders")
         self.short_window = short_window or int(os.getenv("SIGMA_SHORT_WINDOW", "3"))
         self.long_window = long_window or int(os.getenv("SIGMA_LONG_WINDOW", "5"))
-        self.strategy = strategy or MovingAverageStrategy(self.short_window, self.long_window)
+        self.strategy_manager = strategy_manager or StrategyManager()
+        if strategy is not None:
+            self.strategy_manager.register("custom", strategy)
+            self.strategy_manager.change_strategy("custom")
+        else:
+            # 기본 이동 평균 전략 파라미터 반영
+            try:
+                self.strategy_manager.change_strategy("moving_average")
+                strat = self.strategy_manager.current()
+                if hasattr(strat, "short_window"):
+                    strat.short_window = self.short_window
+                if hasattr(strat, "long_window"):
+                    strat.long_window = self.long_window
+            except Exception:
+                pass
         self.risk = risk_manager or RiskManager()
         self.symbol = symbol or os.getenv("SIGMA_SYMBOL", "BTCUSDT")
         self.volume = volume or float(os.getenv("SIGMA_VOLUME", "0"))
@@ -58,7 +74,7 @@ class TradeExecutor:
         processed = 0
 
         async def handle(price: float) -> None:
-            signal = await self.strategy.process(price)
+            signal = await self.strategy_manager.current().process(price)
             if signal in ("BUY", "SELL") and self.risk.check(signal):
                 self.risk.apply(signal)
                 await self.order_executor.execute(

--- a/src/trade_executor.py
+++ b/src/trade_executor.py
@@ -50,8 +50,9 @@ class TradeExecutor:
                     strat.short_window = self.short_window
                 if hasattr(strat, "long_window"):
                     strat.long_window = self.long_window
-            except Exception:
-                pass
+            except Exception as e:
+                import logging
+                logging.error("Failed to change strategy or set strategy parameters: %s", e)
         self.risk = risk_manager or RiskManager()
         self.symbol = symbol or os.getenv("SIGMA_SYMBOL", "BTCUSDT")
         self.volume = volume or float(os.getenv("SIGMA_VOLUME", "0"))

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from src.strategy_manager import StrategyManager  # noqa: E402
+from src.strategy import BaseStrategy  # noqa: E402
+
+
+class DummyStrategy(BaseStrategy):
+    async def process(self, price: float) -> str:
+        return "HOLD"
+
+
+def test_register_and_change():
+    manager = StrategyManager()
+    manager.register("dummy", DummyStrategy())
+    manager.change_strategy("dummy")
+    assert isinstance(manager.current(), DummyStrategy)


### PR DESCRIPTION
## Summary
- implement plugin loader and `StrategyManager`
- refactor `TradeExecutor` and `APIServer` to use the manager
- move `MovingAverageStrategy` into `strategies` package
- update docs to explain strategy management
- add unit test for `StrategyManager`
- update diagrams (generation failed: mmdc not found)

## Testing
- `bash docs/scripts/gen_diagrams.sh` *(fails: mmdc not found)*
- `pre-commit run --files docs/strategy_guide.md docs/components.md docs/admin_manual.md docs/1_architecture/class_diagram.mmd src/strategy_manager.py src/plugin_loader.py src/trade_executor.py src/api_server.py src/strategy.py src/strategies/__init__.py src/strategies/moving_average.py src/__init__.py tests/test_strategy_manager.py` *(fails: command not found)*
- `pytest -q tests/test_strategy_manager.py` *(fails: ModuleNotFoundError: No module named 'websockets')*
