### PR TITLE
Add docstring return consistency test

### DIFF
--- a/tests/test_io_guard.py
+++ b/tests/test_io_guard.py
@@ -59,5 +59,21 @@ def find_return_mismatches():
     return problems
 
 
+def find_docstring_mismatches():
+    problems = []
+    for path in SRC_DIR.rglob('*.py'):
+        tree = ast.parse(path.read_text())
+        for node in [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]:
+            doc = ast.get_docstring(node)
+            returns = ast.unparse(node.returns) if node.returns else None
+            if doc and ("반환" in doc or "return" in doc.lower() or "리턴" in doc):
+                if returns in (None, "None"):
+                    problems.append((path.name, node.name, "docstring says returns but annotation is None"))
+    return problems
+
 def test_return_annotations_consistent():
     assert find_return_mismatches() == []
+
+
+def test_docstring_return_consistent():
+    assert find_docstring_mismatches() == []


### PR DESCRIPTION
## 변경 사항
- docstring과 반환 타입 일치 여부를 검사하는 테스트 추가

## 발견된 불일치 요약
| 파일 | 함수 | 내용 |
| --- | --- | --- |
| 없음 | - | - |

현재 코드에서 불일치는 발견되지 않았습니다.

## 수정 방법 및 타입 변경 내역
- 새로운 검사 함수 `find_docstring_mismatches`를 추가하여 docstring에서 "반환" 혹은 "return"을 언급하지만 `None`으로 어노테이션 된 경우를 탐지합니다.
- 기존 코드에는 해당되는 함수가 없으므로 코드 수정 사항은 없습니다.

## 테스트 결과
모든 테스트가 성공적으로 통과했습니다.
```
$ pytest -q
29 passed, 38 warnings in 2.82s
```


------
https://chatgpt.com/codex/tasks/task_e_6839ff495b0c832eb2b6ec4bc9eb4fb9